### PR TITLE
Fix listDirectoryDetails escaping the directory spaces

### DIFF
--- a/src/FtpClient.php
+++ b/src/FtpClient.php
@@ -257,7 +257,7 @@ class FtpClient
             throw new FtpClientException("[{$directory}] is not a directory.");
         }
 
-        if (!($details = $this->wrapper->rawlist($directory, $recursive))) {
+        if (!($details = $this->wrapper->rawlist(str_replace(' ', '\ ', $directory), $recursive))) {
             throw new FtpClientException(FtpClientException::getFtpServerError()
                 ?: "Unable to get files list for [{$directory}] directory.");
         }


### PR DESCRIPTION
A simple fix to the problem, note that this is not a complete solution and may be not working in some FTP servers. 