### PR TITLE
Fixed [FtpClient::isDir]&[FtpClient::isFile] compatibility with servers that may not support the SIZE feature

### DIFF
--- a/src/FtpClient.php
+++ b/src/FtpClient.php
@@ -157,10 +157,22 @@ class FtpClient
      *
      * @return bool Returns true if the giving file is a directory type, false if it
      *              a file or doesn't exists.
+     *
+     * @throws FtpClientException
      */
     public function isDir($remoteFile)
     {
-        return $this->wrapper->size($remoteFile) === -1;
+        if ($this->isFeatureSupported('SIZE')) {
+            return $this->wrapper->size($remoteFile) === -1;
+        }
+
+        if (($list = $this->listDirectoryDetails($this->dirname($remoteFile))) === false
+            || !array_key_exists($remoteFile, $list)
+            || ($type = $list[$remoteFile]['type']) === '') {
+            return false;
+        }
+
+        return $type === 'dir';
     }
 
     /**
@@ -1074,7 +1086,7 @@ class FtpClient
                 return 'link';
 
             default:
-                return 'unknown file type.';
+                return '';
         }
     }
 

--- a/src/FtpClient.php
+++ b/src/FtpClient.php
@@ -182,10 +182,16 @@ class FtpClient
      *
      * @return bool Returns true if the giving remote file is a regular file, false if it
      *              a directory or doesn't exists.
+     *
+     * @throws FtpClientException
      */
     public function isFile($remoteFile)
     {
-        return $this->wrapper->size($remoteFile) !== -1;
+        if ($this->isFeatureSupported('SIZE')) {
+            return $this->wrapper->size($remoteFile) !== -1;
+        }
+
+        return $this->isExists($remoteFile) && !$this->isDir($remoteFile);
     }
 
     /**


### PR DESCRIPTION
The `SIZE` feature not a standard according to RFC959, thus some FTP servers may not implement this feature, this PR fixes compatibility for the `FtpClient::isDir` and `FtpClient::isFile` that depends directly on the FTP SIZE command.