### PR TITLE
FtpClient::listDirDetails fixed (#21)

### DIFF
--- a/src/FtpClient.php
+++ b/src/FtpClient.php
@@ -239,7 +239,7 @@ class FtpClient
         // './path/to/file' is the same as 'path/to/file'
         $directory = str_replace('./', '', $directory);
 
-        if (!($details = $this->wrapper->rawlist($directory, $recursive))) {
+        if (($details = $this->wrapper->rawlist($directory, $recursive)) === false) {
             throw new FtpClientException($this->wrapper->getErrorMessage()
                 ?: "Unable to get files list for [{$directory}] directory.");
         }


### PR DESCRIPTION
Fixed `FtpClient::listDirDetails` for FTP servers that do not send the DOTS files pointers in directories listing operations. 