### PR TITLE
PHP 7.4 requirement at least and upgrade PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     }
   ],
   "require": {
-    "php": "^7.2 | 8.0.*",
+    "php": "^7.4 | 8.0.*",
     "ext-ftp": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0"
+    "phpunit/phpunit": "^9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
# Changed log

- Setting `php-7.4` version at least.
- Upgrading PHPUnit version to be `^9`.